### PR TITLE
Adding Import / Export Capability 

### DIFF
--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -1,4 +1,3 @@
 export { DataProvider } from "./provider";
 export { useData, useDataDispatch } from "./context";
-export type { State } from "./types";
-export type { User } from "./types.ts";
+export type { State, Action, User } from "./types";

--- a/src/routes/root/data-functions.css
+++ b/src/routes/root/data-functions.css
@@ -5,7 +5,7 @@
   justify-content: space-around;
   width: 6em;
 }
-button:hover span {
+#data-fns-wrapper button:hover span {
   display: flex;
   flex-direction: row;
   float: right;
@@ -14,7 +14,7 @@ button:hover span {
   color: #535bf2;
 }
 @media (prefers-color-scheme: light) {
-  button:hover span {
+  #data-fns-wrapper button:hover span {
     color: #747bff;
   }
 }

--- a/src/routes/root/data-functions.css
+++ b/src/routes/root/data-functions.css
@@ -1,0 +1,20 @@
+#data-fns-wrapper {
+  display: flex;
+  flex-direction: row;
+  float: right;
+  justify-content: space-around;
+  width: 6em;
+}
+button:hover span {
+  display: flex;
+  flex-direction: row;
+  float: right;
+  justify-content: space-around;
+  width: 6em;
+  color: #535bf2;
+}
+@media (prefers-color-scheme: light) {
+  button:hover span {
+    color: #747bff;
+  }
+}

--- a/src/routes/root/data-functions.tsx
+++ b/src/routes/root/data-functions.tsx
@@ -1,6 +1,86 @@
-export const DataFunctions = () => (
-  <div id="data-fns-wrapper">
-    {/* stubs */}
-    <div id="data-fns">Import Export</div>
-  </div>
-);
+import { PhosphorIcon } from "@khanacademy/wonder-blocks-icon";
+import Export from "@phosphor-icons/core/regular/export.svg";
+import DownloadSimple from "@phosphor-icons/core/regular/download-simple.svg";
+import Clickable from "@khanacademy/wonder-blocks-clickable";
+import "./data-functions.css";
+import { useData, useDataDispatch } from "../../context";
+import { useRef } from "react";
+import type { State } from "../../context";
+
+export const DataFunctions = () => {
+  const data: unknown = useData();
+  const inputReference = useRef<HTMLInputElement>(null);
+  const dispatch = useDataDispatch();
+
+  const handleImport = () => {
+    // Click the hidden input to open the file dialog
+    inputReference.current?.click();
+  };
+
+  const importData = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      // Set up the FileReader to read the file
+      // parse the JSON and dispatch the data
+      const reader = new FileReader();
+      reader.onload = (e: ProgressEvent<FileReader>) => {
+        const result = e.target?.result;
+        if (typeof result === "string") {
+          try {
+            const parsed = JSON.parse(result) as State;
+            if (parsed) {
+              dispatch({
+                type: "data-imported",
+                data: parsed,
+              });
+            }
+          } catch (error) {
+            console.error("Failed to parse JSON:", error);
+          }
+        }
+      };
+      reader.onerror = () => {
+        console.error("Failed to read file:", reader.error);
+      };
+      reader.readAsText(file);
+    }
+  };
+
+  const handleExport = () => {
+    // TODO: We could export this with the user's name
+    // so that it's easier for managers to find the right file
+    const fileName = "competencies.json";
+
+    // Create a blob link, download it, and remove the link
+    const blob = new Blob([JSON.stringify(data)], { type: "text/json" });
+    const jsonURL = window.URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    document.body.appendChild(link);
+    link.href = jsonURL;
+    link.setAttribute("download", fileName);
+    link.click();
+    document.body.removeChild(link);
+  };
+
+  return (
+    <div id="data-fns-wrapper">
+      <Clickable
+        role="button"
+        aria-label="Export"
+        onClick={handleExport}
+        id="export"
+      >
+        {() => <PhosphorIcon icon={Export} size="large" />}
+      </Clickable>
+      <Clickable
+        role="button"
+        aria-label="Import"
+        onClick={handleImport}
+        id="import"
+      >
+        {() => <PhosphorIcon icon={DownloadSimple} size="large" />}
+      </Clickable>
+      <input type="file" hidden ref={inputReference} onChange={importData} />
+    </div>
+  );
+};

--- a/src/routes/root/data-functions.tsx
+++ b/src/routes/root/data-functions.tsx
@@ -6,9 +6,10 @@ import "./data-functions.css";
 import { useData, useDataDispatch } from "../../context";
 import { useRef } from "react";
 import type { State } from "../../context";
+import { handleExport, importData } from "./data-utils.ts";
 
-export const DataFunctions = () => {
-  const data: unknown = useData();
+const DataFunctions = () => {
+  const data: State = useData();
   const inputReference = useRef<HTMLInputElement>(null);
   const dispatch = useDataDispatch();
 
@@ -17,57 +18,14 @@ export const DataFunctions = () => {
     inputReference.current?.click();
   };
 
-  const importData = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file) {
-      // Set up the FileReader to read the file
-      // parse the JSON and dispatch the data
-      const reader = new FileReader();
-      reader.onload = (e: ProgressEvent<FileReader>) => {
-        const result = e.target?.result;
-        if (typeof result === "string") {
-          try {
-            const parsed = JSON.parse(result) as State;
-            if (parsed) {
-              dispatch({
-                type: "data-imported",
-                data: parsed,
-              });
-            }
-          } catch (error) {
-            console.error("Failed to parse JSON:", error);
-          }
-        }
-      };
-      reader.onerror = () => {
-        console.error("Failed to read file:", reader.error);
-      };
-      reader.readAsText(file);
-    }
-  };
-
-  const handleExport = () => {
-    // TODO: We could export this with the user's name
-    // so that it's easier for managers to find the right file
-    const fileName = "competencies.json";
-
-    // Create a blob link, download it, and remove the link
-    const blob = new Blob([JSON.stringify(data)], { type: "text/json" });
-    const jsonURL = window.URL.createObjectURL(blob);
-    const link = document.createElement("a");
-    document.body.appendChild(link);
-    link.href = jsonURL;
-    link.setAttribute("download", fileName);
-    link.click();
-    document.body.removeChild(link);
-  };
-
   return (
     <div id="data-fns-wrapper">
       <Clickable
         role="button"
         aria-label="Export"
-        onClick={handleExport}
+        onClick={() => {
+          handleExport(data);
+        }}
         id="export"
       >
         {() => <PhosphorIcon icon={Export} size="large" />}
@@ -80,7 +38,16 @@ export const DataFunctions = () => {
       >
         {() => <PhosphorIcon icon={DownloadSimple} size="large" />}
       </Clickable>
-      <input type="file" hidden ref={inputReference} onChange={importData} />
+      <input
+        type="file"
+        aria-label="File Upload"
+        hidden
+        ref={inputReference}
+        onChange={(e) => {
+          importData(e, dispatch);
+        }}
+      />
     </div>
   );
 };
+export default DataFunctions;

--- a/src/routes/root/data-functions.tsx
+++ b/src/routes/root/data-functions.tsx
@@ -1,10 +1,13 @@
+import { useRef } from "react";
+import Clickable from "@khanacademy/wonder-blocks-clickable";
 import { PhosphorIcon } from "@khanacademy/wonder-blocks-icon";
+
 import Export from "@phosphor-icons/core/regular/export.svg";
 import DownloadSimple from "@phosphor-icons/core/regular/download-simple.svg";
-import Clickable from "@khanacademy/wonder-blocks-clickable";
-import "./data-functions.css";
+
 import { useData, useDataDispatch } from "../../context";
-import { useRef } from "react";
+import "./data-functions.css";
+
 import type { State } from "../../context";
 import { handleExport, importData } from "./data-utils.ts";
 

--- a/src/routes/root/data-functions.tsx
+++ b/src/routes/root/data-functions.tsx
@@ -9,7 +9,7 @@ import { useData, useDataDispatch } from "../../context";
 import "./data-functions.css";
 
 import type { State } from "../../context";
-import { handleExport, importData } from "./data-utils.ts";
+import { exportData, importData } from "./data-utils.ts";
 
 const DataFunctions = () => {
   const data: State = useData();
@@ -27,7 +27,7 @@ const DataFunctions = () => {
         role="button"
         aria-label="Export"
         onClick={() => {
-          handleExport(data);
+          exportData(data);
         }}
         id="export"
       >

--- a/src/routes/root/data-utils.ts
+++ b/src/routes/root/data-utils.ts
@@ -32,7 +32,7 @@ export const importData = (
   }
 };
 
-export const handleExport = (data: State) => {
+export const exportData = (data: State) => {
   // We want to export the file with the user's name
   // so that managers can easily differentiate between
   // multiple files

--- a/src/routes/root/data-utils.ts
+++ b/src/routes/root/data-utils.ts
@@ -1,0 +1,52 @@
+import type { State, Action } from "../../context";
+
+export const importData = (
+  e: React.ChangeEvent<HTMLInputElement>,
+  dispatch: React.Dispatch<Action>,
+) => {
+  const file = e.target.files?.[0];
+  if (file) {
+    // Set up the FileReader to read the file
+    // parse the JSON and dispatch the data
+    const reader = new FileReader();
+    reader.onload = (e: ProgressEvent<FileReader>) => {
+      const result = e.target?.result;
+      if (typeof result === "string") {
+        try {
+          const parsed = JSON.parse(result) as State;
+          if (parsed) {
+            dispatch({
+              type: "data-imported",
+              data: parsed,
+            });
+          }
+        } catch (error) {
+          console.error("Failed to parse JSON:", error);
+        }
+      }
+    };
+    reader.onerror = () => {
+      console.error("Failed to read file:", reader.error);
+    };
+    reader.readAsText(file);
+  }
+};
+
+export const handleExport = (data: State) => {
+  // We want to export the file with the user's name
+  // so that managers can easily differentiate between
+  // multiple files
+  const fileName = data.user
+    ? data.user.firstName + data.user.lastName + "-Competencies.json"
+    : "Competencies.json";
+
+  // Create a blob link, download it, and remove the link
+  const blob = new Blob([JSON.stringify(data)], { type: "text/json" });
+  const jsonURL = window.URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  document.body.appendChild(link);
+  link.href = jsonURL;
+  link.setAttribute("download", fileName);
+  link.click();
+  document.body.removeChild(link);
+};

--- a/src/routes/root/header.tsx
+++ b/src/routes/root/header.tsx
@@ -1,0 +1,7 @@
+import { DataFunctions } from "./data-functions";
+
+export const Header = () => (
+  <>
+    <DataFunctions />
+  </>
+);

--- a/src/routes/root/header.tsx
+++ b/src/routes/root/header.tsx
@@ -1,4 +1,4 @@
-import { DataFunctions } from "./data-functions";
+import DataFunctions from "./data-functions";
 
 export const Header = () => (
   <>

--- a/src/routes/root/root.tsx
+++ b/src/routes/root/root.tsx
@@ -1,10 +1,10 @@
 import { Outlet } from "react-router-dom";
 import { Nav } from "./nav";
-import { DataFunctions } from "./data-functions";
+import { Header } from "./header";
 
 export const Root = () => (
   <>
-    <DataFunctions />
+    <Header />
     <Outlet />
     <Nav />
   </>


### PR DESCRIPTION
Added capability to import and export your competencies! It should export the json file with the following naming format: `[firstName][lastName]-Competencies.json`. If no user is available, we'll instead just call the file "Competencies.json". 

I had tried to write some tests, but I ran into a few issues regarding rendering as well as getting the FileReader to properly mock. In the spirit of hackathon -- we'll come back to it! 

Some other notes:
- I feel like the icons are far too big for mobile, but the available options for the Khan Academy version of Phosphor icons is extremely limited, and "medium" is far too small. I wrote a little style to automatically scale the icons based on the em value, but it felt a little hacky so I kept it out of this PR. 
- I feel like the buttons should really have a hover state tooltip, but I don't think the tooltip package is available. I figured this is lower priority and could possibly be tackled later -- but if it's desirable I could import that now and set it up. 

Issue: This solves Issue #10 

# Screenshot:
![Screenshot 2023-11-01 at 2 15 46 PM](https://github.com/Khan/career-competencies/assets/12463099/ec7ddcf0-ebf4-4a60-96bd-bb0e63452d59)

# Video:
https://github.com/Khan/career-competencies/assets/12463099/8c920cec-effa-4a2e-ae0a-c82553ace0a8


