### PR TITLE
Update career track to show saved info

### DIFF
--- a/src/routes/profile/profile.tsx
+++ b/src/routes/profile/profile.tsx
@@ -94,6 +94,7 @@ export const Profile = () => {
           onChange={(e: ChangeEvent<HTMLSelectElement>) => {
             setTrack(e.target.value as Track);
           }}
+          value={track}
         >
           {trackOptions.map((option) => (
             <option key={option.label}>{option.value}</option>


### PR DESCRIPTION
Missed one line when updating the profile to use a native select versus react-select. This allows the Career Track dropdown to correctly reflect the data saved in local storage.