### PR TITLE
Add navigation blocker if no track selected

### DIFF
--- a/src/routes/profile/profile.css
+++ b/src/routes/profile/profile.css
@@ -1,8 +1,19 @@
 #profile-form {
   display: flex;
   flex-direction: column;
-  flex-wrap: wrap;
-  row-gap: 1em;
+  row-gap: 1.5em;
+  width: 100%;
+}
+
+#profile {
+  display: flex;
+  flex-direction: column;
+  row-gap: 1.5em;
+  justify-content: center;
+  align-items: center;
+  height: auto;
+  width: 100%;
+  height: 100%;
 }
 
 #profile-form * {
@@ -10,25 +21,38 @@
 }
 
 .form__input {
-  min-height: 2em;
   box-sizing: border-box;
-  font-size: 0.8em;
+  font-size: 1em;
   padding-inline: 0.2em;
 }
 
-#form__save-button {
+#blocker-msg {
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
+}
+
+#blocker-btns {
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  width: 100%;
+  gap: 1em;
+  height: min-content;
+}
+
+.profile-btn {
   text-align: center;
-  margin-top: 1em;
   background-color: #646cff !important;
   color: white;
 }
 
-#form__save-button:hover {
+.profile-btn:hover {
   background-color: #535bf2 !important;
 }
 
 @media (prefers-color-scheme: light) {
-  #form__save-button:hover {
+  .profile-btn:hover {
     background-color: #747bff;
   }
 }


### PR DESCRIPTION
Add blocker to encourage selection of track.

Now, when you attempt to navigate away from the profile page without specifying a `Track`, a warning will appear.

This blocker only works for users who have not visited the app before, or for returning users who delete their localStorage.

[Screencast from 11-10-2023 10:39:33 PM.webm](https://github.com/Khan/career-competencies/assets/23404711/6fd822e1-bb5b-4308-930e-9b8c984e5db9)


Resolves #68