### PR TITLE
Add header to overview with list of functional areas

### DIFF
--- a/src/data/tracks.ts
+++ b/src/data/tracks.ts
@@ -21,37 +21,37 @@ export const Tracks: readonly Track[] = [
   {
     key: "dataInsights",
     title: "Data Insights",
-    functions: ["Engineering", "Core"],
+    functions: ["Core", "Engineering"],
   },
   {
     key: "itProfessional",
     title: "IT Professional",
-    functions: ["Engineering", "Core"],
+    functions: ["Core", "Engineering"],
   },
   {
     key: "engManagement",
     title: "Management, Engineering",
-    functions: ["Engineering", "Management", "Core"],
+    functions: ["Core", "Management", "Engineering"],
   },
   {
     key: "softwareEngineer",
     title: "Software Engineer",
-    functions: ["Engineering", "Core"],
+    functions: ["Core", "Engineering"],
   },
   {
     key: "qualityAnalyst",
     title: "Quality Analyst",
-    functions: ["Engineering", "Core"],
+    functions: ["Core", "Engineering"],
   },
   {
     key: "qualityEngineer",
     title: "Quality Engineer",
-    functions: ["Engineering", "Core"],
+    functions: ["Core", "Engineering"],
   },
   {
     key: "otherManagement",
     title: "Management, Other",
-    functions: ["Management", "Core"],
+    functions: ["Core", "Management"],
   },
 ] as const;
 

--- a/src/routes/overview/overview.tsx
+++ b/src/routes/overview/overview.tsx
@@ -7,9 +7,7 @@ export const Overview = () => {
   const { user } = useData();
   return (
     <span id="overview">
-      <h3>
-        Competencies: {user?.track?.functions.join(", ") ?? "Core"}
-      </h3>
+      <h3>Competencies: {user?.track?.functions.join(", ") ?? "Core"}</h3>
       {Matrix(user?.track ?? getTrack("core")).byCompetency.map(
         (competency) => (
           <CompetencyItem key={competency.key} competency={competency} />

--- a/src/routes/overview/overview.tsx
+++ b/src/routes/overview/overview.tsx
@@ -5,14 +5,31 @@ import "./overview.css";
 
 export const Overview = () => {
   const { user } = useData();
+  const track = user?.track ?? getTrack("core");
+  const functions = user?.track?.functions ?? ["core"];
   return (
     <span id="overview">
-      <h3>Competencies: {user?.track?.functions.join(", ") ?? "Core"}</h3>
-      {Matrix(user?.track ?? getTrack("core")).byCompetency.map(
-        (competency) => (
-          <CompetencyItem key={competency.key} competency={competency} />
-        ),
+      {user?.track?.title ? (
+        <h3>Competencies for {user.track.title}</h3>
+      ) : (
+        <h3>Track not selected; visit </h3>
       )}
+      {functions.map((funcArea) => (
+        <>
+          <h6
+            key={funcArea}
+            style={{ margin: "1em 0 0 0", textTransform: "uppercase" }}
+          >
+            {funcArea}
+          </h6>
+          {track &&
+            Matrix(track)
+              .byCompetency.filter((comp) => comp.functionalArea === funcArea)
+              .map((competency) => (
+                <CompetencyItem key={competency.key} competency={competency} />
+              ))}
+        </>
+      ))}
     </span>
   );
 };

--- a/src/routes/overview/overview.tsx
+++ b/src/routes/overview/overview.tsx
@@ -7,6 +7,9 @@ export const Overview = () => {
   const { user } = useData();
   return (
     <span id="overview">
+      <h3>
+        Competencies: {user?.track?.functions.join(", ") ?? "Core"}
+      </h3>
       {Matrix(user?.track ?? getTrack("core")).byCompetency.map(
         (competency) => (
           <CompetencyItem key={competency.key} competency={competency} />

--- a/src/routes/questionnaire/prompt.tsx
+++ b/src/routes/questionnaire/prompt.tsx
@@ -1,5 +1,5 @@
 import { useLoaderData } from "react-router-dom";
-import type { Skill } from "../../data";
+import { Competencies, type Skill } from "../../data";
 import { useData, useDataDispatch } from "../../context";
 
 import "./questionnaire.css";
@@ -17,8 +17,15 @@ export const Prompt = () => {
     examples: {},
   };
 
+  const functionalArea = Competencies.find(
+    ({ key }) => key === skill.competency,
+  )?.functionalArea;
+
   return (
     <div id="prompt">
+      <span style={{ textTransform: "uppercase", fontSize: "0.8em" }}>
+        {functionalArea} Competency Skill
+      </span>
       <SkillNav skill={skill} />
       <Checkbox
         id={skill.id}


### PR DESCRIPTION
Adds a header to Overview that lists functional areas for competencies, which are derived from Track.

![Screenshot from 2023-11-10 23-37-05](https://github.com/Khan/career-competencies/assets/23404711/6d4f1619-b41b-41e5-ae5c-60b13800884a)

Resolves #68 a little more.